### PR TITLE
Убран перевод на начало строки в TextFormatter при пустом контексте

### DIFF
--- a/src/Formatters/TextFormatter.php
+++ b/src/Formatters/TextFormatter.php
@@ -12,7 +12,8 @@ use Fi1a\Log\Record;
  */
 class TextFormatter extends AbstractFormatter
 {
-    public const DEFAULT_FORMAT = "{{datetime}}\n{{channel}}.{{levelName}}[{{level}}]\n{{message}}\n{{context}}\n\n";
+    public const DEFAULT_FORMAT = "{{datetime}}\n{{channel}}.{{levelName}}[{{level}}]\n{{message}}"
+        . "{{if(context)}}\n{{context}}{{endif}}\n\n";
 
     /**
      * @var string

--- a/tests/Formatters/TextFormatterTest.php
+++ b/tests/Formatters/TextFormatterTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Fi1a\Unit\Log\Formatters;
 
+use DateTime;
 use Fi1a\Log\Formatters\TextFormatter;
+use Fi1a\Log\Level;
+use Fi1a\Log\LevelInterface;
+use Fi1a\Log\Record;
 use Fi1a\Unit\Log\TestCases\LoggerTestCase;
 
 use const PHP_EOL;
@@ -44,6 +48,30 @@ class TextFormatterTest extends LoggerTestCase
             . 'test testValue message '
             . '{"id":1}' . PHP_EOL,
             $formatter->format($this->getRecord())
+        );
+    }
+
+    /**
+     * Форматирование с пустым контекстом
+     */
+    public function testFormatEmptyContext()
+    {
+        $record = new Record(
+            DateTime::createFromFormat('d.m.Y H:i:s', '11.01.2023 05:41:56'),
+            Level::fromValue(LevelInterface::ALERT),
+            'default',
+            'test {{value}} message',
+            [
+                'value' => 'testValue',
+            ]
+        );
+        $formatter = new TextFormatter();
+        $this->assertEquals(
+            '11.01.2023 05:41:56' . PHP_EOL
+            . 'default.ALERT[700]' . PHP_EOL
+            . 'test testValue message'
+            . PHP_EOL . PHP_EOL,
+            $formatter->format($record)
         );
     }
 }


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Is bugfix?    |  :heavy_check_mark:   |
| New feature?	 |  :x:   |
| Is refactoring?    |  :x:   |
| Fixed issues  |     |

Checklist

| Q                 | A   |
|-------------------|-----|
| Is tests written? |  :heavy_check_mark:   |
| Is docs updated?	 |  :x:   |